### PR TITLE
Cache keyword analysis results

### DIFF
--- a/src/main/java/com/example/companyReputationManagement/dao/ReviewDao.java
+++ b/src/main/java/com/example/companyReputationManagement/dao/ReviewDao.java
@@ -1,7 +1,6 @@
 package com.example.companyReputationManagement.dao;
 
 import com.example.companyReputationManagement.dto.review.get_all_by_sent.GetAllBySentResponseDTO;
-import com.example.companyReputationManagement.dto.review.keyWord.KeyWordResponseDTO;
 import com.example.companyReputationManagement.dto.review.keyWord.bot.BotReviewDTO;
 import com.example.companyReputationManagement.models.Review;
 import com.example.companyReputationManagement.models.enums.SentimentTypeEnum;
@@ -10,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -46,6 +44,10 @@ public class ReviewDao {
     }
     public List<BotReviewDTO> findForAnalysis(Long compId, SentimentTypeEnum sentId) {
         return reviewRepo.findForAnalysis(compId, sentId);
+    }
+
+    public Timestamp findLatestReviewDate(Long compId, SentimentTypeEnum sentId) {
+        return reviewRepo.findLatestReviewDate(compId, sentId);
     }
 
     public Double getAverageRating(Long compId, Timestamp start, Timestamp end) {

--- a/src/main/java/com/example/companyReputationManagement/dao/ReviewInsightDao.java
+++ b/src/main/java/com/example/companyReputationManagement/dao/ReviewInsightDao.java
@@ -1,0 +1,23 @@
+package com.example.companyReputationManagement.dao;
+
+import com.example.companyReputationManagement.models.ReviewInsight;
+import com.example.companyReputationManagement.models.enums.SentimentTypeEnum;
+import com.example.companyReputationManagement.repo.ReviewInsightRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class ReviewInsightDao {
+    private final ReviewInsightRepo reviewInsightRepo;
+
+    public ReviewInsight save(ReviewInsight insight) {
+        return reviewInsightRepo.save(insight);
+    }
+
+    public Optional<ReviewInsight> findLatest(Long companyId, SentimentTypeEnum sentimentType) {
+        return reviewInsightRepo.findTopByCompanyIdAndSentimentTypeOrderByCreatedAtDesc(companyId, sentimentType);
+    }
+}

--- a/src/main/java/com/example/companyReputationManagement/models/ReviewInsight.java
+++ b/src/main/java/com/example/companyReputationManagement/models/ReviewInsight.java
@@ -1,0 +1,46 @@
+package com.example.companyReputationManagement.models;
+
+import com.example.companyReputationManagement.dto.review.keyWord.bot.BotResponseDTO;
+import com.example.companyReputationManagement.models.enums.SentimentTypeEnum;
+import com.example.companyReputationManagement.models.enums.converters.SentimentTypeRefConverter;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.annotations.JdbcTypeCode;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "review_insights")
+public class ReviewInsight {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "company_id", nullable = false)
+    private Long companyId;
+
+    @Column(name = "sentiment_type", nullable = false)
+    @Convert(converter = SentimentTypeRefConverter.class)
+    private SentimentTypeEnum sentimentType;
+
+    @Column(name = "result_json", nullable = false, columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private BotResponseDTO resultJson;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Timestamp createdAt;
+
+    public ReviewInsight(Long companyId, SentimentTypeEnum sentimentType, BotResponseDTO resultJson) {
+        this.companyId = companyId;
+        this.sentimentType = sentimentType;
+        this.resultJson = resultJson;
+    }
+}

--- a/src/main/java/com/example/companyReputationManagement/repo/ReviewInsightRepo.java
+++ b/src/main/java/com/example/companyReputationManagement/repo/ReviewInsightRepo.java
@@ -1,0 +1,13 @@
+package com.example.companyReputationManagement.repo;
+
+import com.example.companyReputationManagement.models.ReviewInsight;
+import com.example.companyReputationManagement.models.enums.SentimentTypeEnum;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReviewInsightRepo extends JpaRepository<ReviewInsight, Long> {
+    Optional<ReviewInsight> findTopByCompanyIdAndSentimentTypeOrderByCreatedAtDesc(Long companyId, SentimentTypeEnum sentimentType);
+}

--- a/src/main/java/com/example/companyReputationManagement/repo/ReviewRepo.java
+++ b/src/main/java/com/example/companyReputationManagement/repo/ReviewRepo.java
@@ -1,7 +1,6 @@
 package com.example.companyReputationManagement.repo;
 
 import com.example.companyReputationManagement.dto.review.get_all_by_sent.GetAllBySentResponseDTO;
-import com.example.companyReputationManagement.dto.review.keyWord.KeyWordResponseDTO;
 import com.example.companyReputationManagement.dto.review.keyWord.bot.BotReviewDTO;
 import com.example.companyReputationManagement.models.Review;
 import com.example.companyReputationManagement.models.enums.SentimentTypeEnum;
@@ -32,6 +31,10 @@ public interface ReviewRepo extends JpaRepository<Review, Long> {
     @Query("SELECT new com.example.companyReputationManagement.dto.review.keyWord.bot.BotReviewDTO(r.reviewerName,r.content) " +
             "FROM Review r WHERE r.companyId =:companyId AND r.sentimentTypeId =:sentimentTypeId")
     List<BotReviewDTO> findForAnalysis(@Param("companyId") Long companyId, @Param("sentimentTypeId") SentimentTypeEnum sentimentTypeId);
+
+
+    @Query("SELECT MAX(r.publishedDate) FROM Review r WHERE r.companyId =:companyId AND r.sentimentTypeId =:sentimentTypeId")
+    Timestamp findLatestReviewDate(@Param("companyId") Long companyId, @Param("sentimentTypeId") SentimentTypeEnum sentimentTypeId);
 
 
     @Query("SELECT AVG(r.rating) FROM Review r  WHERE r.companyId =:companyId AND r.publishedDate BETWEEN :start AND :endM ")


### PR DESCRIPTION
## Summary
- add a ReviewInsight entity/repository for persisting keyword analysis responses
- reuse cached keyword analysis when no new reviews are present for a company/sentiment
- detect newer reviews via latest publication timestamp before invoking the external bot

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f338700288333a56f2131836900da)