### PR TITLE
Improve Ollama client resilience and configuration

### DIFF
--- a/src/main/java/com/example/companyReputationManagement/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/companyReputationManagement/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.example.companyReputationManagement.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(120))
+                .build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a singleton RestTemplate bean configured with sensible connect and read timeouts
- harden ExternalBotClient with retries, safer prompt/options, and robust JSON extraction/normalization before parsing bot responses

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f42456b908333a2c7158052a09a16)