### PR TITLE
Add review insights section to generated reports

### DIFF
--- a/src/main/java/com/example/companyReputationManagement/iservice/services/review/ReviewService.java
+++ b/src/main/java/com/example/companyReputationManagement/iservice/services/review/ReviewService.java
@@ -389,6 +389,8 @@ public class ReviewService implements IReviewService {
             document.add(chart3);
             document.setPageSize(PageSize.A4.rotate());
         }
+
+        appendReviewInsightsSection(document, compId, bodyFont);
         Paragraph footer = new Paragraph(
                 "The report is generated automatically based on data received from the feedback system..\n" +
                         "For more information, please contact the analytical department..",
@@ -405,6 +407,64 @@ public class ReviewService implements IReviewService {
         }
 
         return out.toByteArray();
+    }
+
+    private void appendReviewInsightsSection(com.itextpdf.text.Document document, Long compId, com.itextpdf.text.Font bodyFont) throws DocumentException {
+        List<ReviewInsight> latestInsights = Arrays.stream(SentimentTypeEnum.values())
+                .map(type -> reviewInsightDao.findLatest(compId, type))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(this::hasInsightContent)
+                .toList();
+
+        if (latestInsights.isEmpty()) {
+            return;
+        }
+
+        document.setPageSize(PageSize.A4);
+        document.newPage();
+
+        com.itextpdf.text.Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
+        com.itextpdf.text.Font subHeaderFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 13, BaseColor.BLACK);
+
+        document.add(new Paragraph("Key insights from reviews", headerFont));
+        document.add(new Paragraph("Summary of highlighted aspects extracted from user feedback.\n", bodyFont));
+
+        for (ReviewInsight insight : latestInsights) {
+            BotResponseDTO response = insight.getResultJson();
+            String title = SentimentTypeEnum.toString(insight.getSentimentType()) + " insights";
+            document.add(new Paragraph(title, subHeaderFont));
+            addInsightsList(document, "Top likes", response.topLikes(), bodyFont);
+            addInsightsList(document, "Top dislikes", response.topDislikes(), bodyFont);
+            addInsightsList(document, "Top requests", response.topRequests(), bodyFont);
+        }
+    }
+
+    private void addInsightsList(com.itextpdf.text.Document document, String title, List<InsightDTO> insights, com.itextpdf.text.Font bodyFont) throws DocumentException {
+        if (insights == null || insights.isEmpty()) {
+            return;
+        }
+
+        document.add(new Paragraph(title, bodyFont));
+        com.itextpdf.text.List list = new com.itextpdf.text.List(false, 10);
+
+        for (InsightDTO insight : insights) {
+            String aspect = insight.aspect() != null ? insight.aspect() + ": " : "";
+            String statement = insight.statement() != null ? insight.statement() : "";
+            String itemText = String.format("%s%s (mentions: %d)", aspect, statement, insight.count());
+            list.add(new ListItem(itemText, bodyFont));
+        }
+
+        document.add(list);
+        document.add(new Paragraph("\n", bodyFont));
+    }
+
+    private boolean hasInsightContent(ReviewInsight insight) {
+        BotResponseDTO response = insight.getResultJson();
+
+        return response != null && ((response.topLikes() != null && !response.topLikes().isEmpty())
+                || (response.topDislikes() != null && !response.topDislikes().isEmpty())
+                || (response.topRequests() != null && !response.topRequests().isEmpty()));
     }
 
     //Проверки


### PR DESCRIPTION
## Summary
- append the latest stored review insights to generated PDF reports after the charts
- group insights by sentiment with lists of top likes, dislikes, and requests

## Testing
- ./gradlew test *(fails: Unable to download Gradle due to proxy 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f723cd66c833388bf7c7992f3098a)