### PR TITLE
Add strict filtering and limits for insights

### DIFF
--- a/src/main/java/com/example/companyReputationManagement/analysis/InsightBuilder.java
+++ b/src/main/java/com/example/companyReputationManagement/analysis/InsightBuilder.java
@@ -29,9 +29,15 @@ public class InsightBuilder {
             if (result.size() >= maxPerCategory) break;
 
             List<Integer> idxs = cl.indices;
+            if (idxs.size() < 2) {
+                continue;
+            }
             int count = idxs.size();
 
             String aspect = buildAspect(texts, idxs);
+            if (!isValidAspect(aspect)) {
+                continue;
+            }
             String statement = buildStatement(aspect, sentiment);
 
             int pick = idxs.get(0);
@@ -47,7 +53,21 @@ public class InsightBuilder {
             ));
         }
 
-        return result;
+        return result.stream()
+                .sorted(Comparator.comparingInt(InsightDTO::count).reversed())
+                .limit(5)
+                .toList();
+    }
+
+    private static boolean isValidAspect(String s) {
+        if (s == null) return false;
+        s = s.trim().toLowerCase();
+
+        if (s.length() < 3) return false;
+        if (s.matches("[\\p{Punct}\\d\\s]+")) return false;
+        if (Set.of("censored", "unknown", "null").contains(s)) return false;
+
+        return true;
     }
 
     private static String buildAspect(List<String> texts, List<Integer> idxs) {

--- a/src/main/java/com/example/companyReputationManagement/iservice/services/review/ReviewService.java
+++ b/src/main/java/com/example/companyReputationManagement/iservice/services/review/ReviewService.java
@@ -441,6 +441,8 @@ public class ReviewService implements IReviewService {
         com.itextpdf.text.List list = new com.itextpdf.text.List(false, 10);
 
         for (InsightDTO insight : insights) {
+            if (!isValidAspect(insight.aspect())) continue;
+            if (insight.count() < 2) continue;
             String aspect = insight.aspect() != null ? insight.aspect() + ": " : "";
             String statement = insight.statement() != null ? insight.statement() : "";
             String itemText = String.format("%s%s (mentions: %d)", aspect, statement, insight.count());
@@ -458,6 +460,17 @@ public class ReviewService implements IReviewService {
         String userCode = jwtService.extractUserCodeFromJwt();
         RoleEnum currentRole = userCompanyRolesDao.findRoleByUserCode(userCode, compId);
         return currentRole.equals(RoleEnum.OWNER) || currentRole.equals(RoleEnum.ADMIN);
+    }
+
+    private static boolean isValidAspect(String s) {
+        if (s == null) return false;
+        s = s.trim().toLowerCase();
+
+        if (s.length() < 3) return false;
+        if (s.matches("[\\p{Punct}\\d\\s]+")) return false;
+        if (Set.of("censored", "unknown", "null").contains(s)) return false;
+
+        return true;
     }
 
     private boolean checkEmployment(Long compId) {


### PR DESCRIPTION
## Summary
- filter out invalid aspects and single-item clusters before creating insights
- cap stored insights to the top five by frequency per sentiment category
- apply aspect and count validation when rendering insights in PDF reports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694080bbb5608333a3ffe8226f189a12)