### PR TITLE
Allow insights to be generated from single-review clusters

### DIFF
--- a/src/main/java/com/example/companyReputationManagement/analysis/InsightBuilder.java
+++ b/src/main/java/com/example/companyReputationManagement/analysis/InsightBuilder.java
@@ -29,9 +29,6 @@ public class InsightBuilder {
             if (result.size() >= maxPerCategory) break;
 
             List<Integer> idxs = cl.indices;
-            if (idxs.size() < 2) {
-                continue;
-            }
             int count = idxs.size();
 
             String aspect = buildAspect(texts, idxs);

--- a/src/test/java/com/example/companyReputationManagement/analysis/InsightBuilderTest.java
+++ b/src/test/java/com/example/companyReputationManagement/analysis/InsightBuilderTest.java
@@ -1,0 +1,39 @@
+package com.example.companyReputationManagement.analysis;
+
+import com.example.companyReputationManagement.dto.review.keyWord.bot.InsightDTO;
+import com.example.companyReputationManagement.models.enums.Sentiment;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InsightBuilderTest {
+
+    @Test
+    void returnsInsightEvenForSingleReviewCluster() {
+        var clusters = List.of(new OnlineClustering.Cluster());
+        clusters.getFirst().indices.add(0);
+        clusters.getFirst().centroid = new double[]{1.0, 0.0};
+
+        List<String> ids = List.of("review-1");
+        List<String> texts = List.of("Отличная поддержка клиентов и быстрая доставка");
+
+        List<InsightDTO> insights = InsightBuilder.toInsights(
+                ids,
+                texts,
+                clusters,
+                Sentiment.POSITIVE,
+                3,
+                120
+        );
+
+        assertThat(insights)
+                .hasSize(1)
+                .allSatisfy(insight -> {
+                    assertThat(insight.aspect()).isNotBlank();
+                    assertThat(insight.count()).isEqualTo(1);
+                    assertThat(insight.sentiment()).isEqualTo(Sentiment.POSITIVE);
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- allow insight generation even when a cluster contains a single review
- add a unit test to ensure insights are returned for single-review clusters

## Testing
- ./gradlew test --no-daemon *(fails: Java 23 toolchain not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69409d0c99748333bfaa11d6ab41c3c5)