### PR TITLE
Fix water BDD scenarios and wire temperature into water norm API

### DIFF
--- a/src/main/java/com/example/companyReputationManagement/controllers/labController/FuncController.java
+++ b/src/main/java/com/example/companyReputationManagement/controllers/labController/FuncController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/water")
+@RequestMapping("/api/water")
 public class FuncController {
     private final ILabService labService;
 
@@ -24,7 +24,7 @@ public class FuncController {
 
         HttpResponseBody<ResponseTestDTO> response = labService.getVolume(requestTestDTO);
 
-        if (requestTestDTO.weight() == 2f) {
+        if (response.getResponseEntity() == null) {
             return ResponseEntity.badRequest().body(response);
         }
 

--- a/src/main/java/com/example/companyReputationManagement/controllers/labController/WeatherController.java
+++ b/src/main/java/com/example/companyReputationManagement/controllers/labController/WeatherController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/weather")
+@RequestMapping("/api/weather")
 public class WeatherController {
     private final ILabService labService;
 

--- a/src/main/java/com/example/companyReputationManagement/iservice/services/lab/LabService.java
+++ b/src/main/java/com/example/companyReputationManagement/iservice/services/lab/LabService.java
@@ -11,7 +11,6 @@ import com.example.companyReputationManagement.mapper.LabMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
 
 import static com.example.companyReputationManagement.constants.SysConst.OC_BUGS;
 import static com.example.companyReputationManagement.constants.SysConst.OC_OK;
@@ -51,7 +50,10 @@ public class LabService implements ILabService {
 
             return response;
         }
-        ResponseTestDTO responseTestDTO = labMapper.createResponse(weight, time);
+        Float temp = requestTestDTO.temp();
+        ResponseTestDTO responseTestDTO = (temp == null)
+                ? labMapper.createResponse(weight, time)
+                : labMapper.createResponse(weight, time, temp);
         if (responseTestDTO.volume() == null) {
             response.setError("Ошибка подсчёта");
             response.setMessage("Ошибка при подсчёте данных");

--- a/src/test/java/com/example/companyReputationManagement/lab/steps/WaterSteps.java
+++ b/src/test/java/com/example/companyReputationManagement/lab/steps/WaterSteps.java
@@ -1,50 +1,126 @@
 package com.example.companyReputationManagement.lab.steps;
 
-import com.example.companyReputationManagement.dto.lab.RequestTestDTO;
-import com.example.companyReputationManagement.dto.lab.ResponseTestDTO;
-import com.example.companyReputationManagement.httpResponse.HttpResponseBody;
-import com.example.companyReputationManagement.iservice.ILabService;
+import com.example.companyReputationManagement.controllers.labController.FuncController;
+import com.example.companyReputationManagement.controllers.labController.WeatherController;
+import com.example.companyReputationManagement.iservice.services.lab.LabService;
+import com.example.companyReputationManagement.iservice.services.lab.WeatherService;
+import com.example.companyReputationManagement.mapper.LabMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.junit.jupiter.api.Assertions;
-import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 public class WaterSteps {
 
-    private final ILabService labService = Mockito.mock(ILabService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MockMvc mockMvc;
 
-    private HttpResponseBody<ResponseTestDTO> response;
-    private float temp;
+    private MvcResult lastResult;
+    private float receivedTemp;
+    private final Map<String, Float> rememberedVolumes = new HashMap<>();
 
-    @Given("weather service is available")
-    public void weatherServiceIsAvailable() {
+    public WaterSteps() {
+        WeatherService weatherService = new WeatherService();
+        LabMapper labMapper = new LabMapper(weatherService);
+        LabService labService = new LabService(labMapper);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(
+                new WeatherController(labService),
+                new FuncController(labService)
+        ).build();
+    }
+
+    @Given("water APIs are available")
+    public void waterApisAreAvailable() {
+        Assertions.assertNotNull(mockMvc);
     }
 
     @When("I request temperature for city {string}")
-    public void iRequestTemperatureForCity(String city) {
-        temp = 10f;
+    public void iRequestTemperatureForCity(String city) throws Exception {
+        lastResult = mockMvc.perform(get("/api/weather/{city}", city)).andReturn();
+        JsonNode body = objectMapper.readTree(lastResult.getResponse().getContentAsString());
+        receivedTemp = (float) body.path("responseEntity").path("temp").asDouble();
     }
 
-    @When("I calculate water norm with weight {int} and time {int}")
-    public void iCalculateWaterNormWithWeightAndTime(int weight, int time) {
-        RequestTestDTO request = new RequestTestDTO((float) weight, (float) time, temp);
-        response = labService.getVolume(request);
+    @When("I calculate water norm with weight {int} and time {int} using received temperature")
+    public void iCalculateWaterNormWithWeightAndTimeUsingReceivedTemperature(int weight, int time) throws Exception {
+        calculate(weight, time, receivedTemp);
     }
 
     @When("I calculate water norm with weight {int} and time {int} at temperature {int}")
-    public void iCalculateWaterNormWithWeightAndTimeAtTemperature(int weight, int time, int tempValue) {
-        RequestTestDTO request = new RequestTestDTO((float) weight, (float) time, (float) tempValue);
-        response = labService.getVolume(request);
+    public void iCalculateWaterNormWithWeightAndTimeAtTemperature(int weight, int time, int tempValue) throws Exception {
+        calculate(weight, time, tempValue);
+    }
+
+    @When("I remember calculated water volume as {string}")
+    public void iRememberCalculatedWaterVolumeAs(String key) throws Exception {
+        rememberedVolumes.put(key, getVolumeFromLastResponse());
     }
 
     @Then("response status should be {int}")
     public void responseStatusShouldBe(int status) {
-        Assertions.assertNotNull(response);
+        Assertions.assertNotNull(lastResult);
+        Assertions.assertEquals(status, lastResult.getResponse().getStatus());
     }
 
     @Then("calculated water volume should be greater than {int}")
-    public void calculatedWaterVolumeShouldBeGreaterThan(int value) {
-        Assertions.assertNotNull(response);
+    public void calculatedWaterVolumeShouldBeGreaterThan(int value) throws Exception {
+        Assertions.assertTrue(getVolumeFromLastResponse() > value);
+    }
+
+    @Then("calculated water volume should be {word} {int}")
+    public void calculatedWaterVolumeShouldBeComparison(String comparison, int value) throws Exception {
+        JsonNode body = objectMapper.readTree(lastResult.getResponse().getContentAsString());
+        JsonNode volumeNode = body.path("responseEntity").path("volume");
+
+        if ("absent".equals(comparison)) {
+            Assertions.assertTrue(volumeNode.isMissingNode() || volumeNode.isNull());
+            return;
+        }
+
+        float volume = getVolumeFromLastResponse();
+        if ("greater".equals(comparison)) {
+            Assertions.assertTrue(volume > value);
+        } else {
+            Assertions.fail("Unsupported comparison: " + comparison);
+        }
+    }
+
+    @Then("calculated water volume should be greater than remembered {string}")
+    public void calculatedWaterVolumeShouldBeGreaterThanRemembered(String key) throws Exception {
+        Float remembered = rememberedVolumes.get(key);
+        Assertions.assertNotNull(remembered, "Remembered value was not saved: " + key);
+        Assertions.assertTrue(getVolumeFromLastResponse() > remembered);
+    }
+
+    private void calculate(float weight, float time, float temp) throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "weight", weight,
+                "time", time,
+                "temp", temp
+        ));
+
+        lastResult = mockMvc.perform(post("/api/water/norm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn();
+    }
+
+    private float getVolumeFromLastResponse() throws Exception {
+        JsonNode body = objectMapper.readTree(lastResult.getResponse().getContentAsString());
+        JsonNode volumeNode = body.path("responseEntity").path("volume");
+        Assertions.assertFalse(volumeNode.isMissingNode() || volumeNode.isNull(), "Volume is missing in response");
+        return (float) volumeNode.asDouble();
     }
 }

--- a/src/test/resources/features/water.feature
+++ b/src/test/resources/features/water.feature
@@ -1,18 +1,26 @@
 Feature: Daily water norm calculation
 
   Scenario: Get temperature and calculate water norm
-    Given weather service is available
+    Given water APIs are available
     When I request temperature for city "Minsk"
-    And I calculate water norm with weight 70 and time 60
+    And I calculate water norm with weight 70 and time 60 using received temperature
     Then response status should be 200
     And calculated water volume should be greater than 0
 
-  Scenario Outline: Check different weight and temperature values
+  Scenario Outline: Check weight and temperature combinations
     When I calculate water norm with weight <weight> and time 60 at temperature <temp>
     Then response status should be <status>
+    And calculated water volume should be <comparison> <volume>
 
     Examples:
-      | weight | temp | status |
-      | 70     | 20   | 200    |
-      | 70     | 35   | 200    |
-      | 2      | 20   | 400    |
+      | weight | temp | status | comparison | volume |
+      | 70     | 20   | 200    | greater    | 0      |
+      | 70     | 35   | 200    | greater    | 0      |
+      | 2      | 20   | 400    | absent     | 0      |
+
+  Scenario: Water norm increases when temperature is above 30°C
+    When I calculate water norm with weight 70 and time 60 at temperature 30
+    And I remember calculated water volume as "base"
+    And I calculate water norm with weight 70 and time 60 at temperature 35
+    Then response status should be 200
+    And calculated water volume should be greater than remembered "base"


### PR DESCRIPTION
### Motivation
- Реализовать вариант BDD: получить температуру из погоды и передать её в API расчёта дневной нормы воды, с `Scenario Outline` для комбинаций веса/температуры и проверками на рост нормы при `temp > 30°C` и ошибку `400` для недопустимого веса.

### Description
- Изменены маршруты контроллеров на требуемые: `WeatherController` на `GET /api/weather/{city}` и `FuncController` на `POST /api/water/norm`.
- Исправлена логика контроллера `FuncController` чтобы возвращать `400 Bad Request` когда расчёт не вернул `responseEntity` вместо хардкода по весу `2f`.
- В `LabService#getVolume` добавлена обработка `requestTestDTO.temp()` и передача температуры в `LabMapper.createResponse(...)` при наличии, чтобы расчёт мог использовать внешнюю температуру.
- Переписаны BDD-артефакты: `src/test/resources/features/water.feature` обновлён с `Scenario Outline` и дополнительным сценарием на сравнение, а step-definitions `WaterSteps` переписан для интеграционного вызова контроллеров через `MockMvc` и конкретных проверок ответа (статусы, наличие/отсутствие `volume`, сравнения объёмов).

### Testing
- Попытка запустить Cucumber через `./gradlew test --tests '*CucumberTest'` не прошла в этом окружении из-за несовместимости Java/Gradle: `Unsupported class file major version 69`.
- Нет других автоматических тестов, успешно выполненных в этом среде из-за указанной проблемы с запуском Gradle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4fe439c9c832d97e116e292a68802)